### PR TITLE
switch from embed.FS to a map of bytes

### DIFF
--- a/langs/golang/golang.go
+++ b/langs/golang/golang.go
@@ -5,6 +5,7 @@
 package golang
 
 import (
+	_ "embed"
 	"fmt"
 	"log"
 	"os"
@@ -14,10 +15,14 @@ import (
 
 	"github.com/goki/ki/indent"
 	"github.com/goki/pi/filecat"
+	"github.com/goki/pi/langs"
 	"github.com/goki/pi/lex"
 	"github.com/goki/pi/pi"
 	"github.com/goki/pi/token"
 )
+
+//go:embed go.pi
+var parserBytes []byte
 
 // GoLang implements the Lang interface for the Go language
 type GoLang struct {
@@ -29,8 +34,7 @@ var TheGoLang = GoLang{}
 
 func init() {
 	pi.StdLangProps[filecat.Go].Lang = &TheGoLang
-	if pi.StdLangProps[filecat.Go].Lang == nil {
-	}
+	langs.ParserBytes[filecat.Go] = parserBytes
 }
 
 func (gl *GoLang) Parser() *pi.Parser {

--- a/langs/langs.go
+++ b/langs/langs.go
@@ -5,24 +5,17 @@
 package langs
 
 import (
-	"embed"
-	"path/filepath"
-	"strings"
+	"fmt"
 
 	"github.com/goki/pi/filecat"
 )
 
-//go:embed golang/go.pi
-//go:embed markdown/markdown.pi
-//go:embed tex/tex.pi
-var content embed.FS
+var ParserBytes map[filecat.Supported][]byte
 
 func OpenParser(sl filecat.Supported) ([]byte, error) {
-	ln := strings.ToLower(sl.String())
-	lndir := ln
-	if lndir == "go" {
-		lndir = "golang" // can't name a package "go"..
+	parserBytes, ok := ParserBytes[sl]
+	if !ok {
+		return nil, fmt.Errorf("langs.OpenParser: no parser bytes for %v", sl)
 	}
-	fn := filepath.Join(lndir, ln+".pi")
-	return content.ReadFile(fn)
+	return parserBytes, nil
 }

--- a/langs/langs.go
+++ b/langs/langs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goki/pi/filecat"
 )
 
-var ParserBytes map[filecat.Supported][]byte
+var ParserBytes map[filecat.Supported][]byte = make(map[filecat.Supported][]byte)
 
 func OpenParser(sl filecat.Supported) ([]byte, error) {
 	parserBytes, ok := ParserBytes[sl]

--- a/langs/markdown/markdown.go
+++ b/langs/markdown/markdown.go
@@ -5,18 +5,23 @@
 package markdown
 
 import (
+	_ "embed"
 	"strings"
 	"unicode"
 
 	"github.com/goki/ki/indent"
 	"github.com/goki/pi/complete"
 	"github.com/goki/pi/filecat"
+	"github.com/goki/pi/langs"
 	"github.com/goki/pi/langs/bibtex"
 	"github.com/goki/pi/lex"
 	"github.com/goki/pi/pi"
 	"github.com/goki/pi/syms"
 	"github.com/goki/pi/token"
 )
+
+//go:embed markdown.pi
+var parserBytes []byte
 
 // MarkdownLang implements the Lang interface for the Markdown language
 type MarkdownLang struct {
@@ -29,6 +34,7 @@ var TheMarkdownLang = MarkdownLang{}
 
 func init() {
 	pi.StdLangProps[filecat.Markdown].Lang = &TheMarkdownLang
+	langs.ParserBytes[filecat.Markdown] = parserBytes
 }
 
 func (ml *MarkdownLang) Parser() *pi.Parser {

--- a/langs/tex/tex.go
+++ b/langs/tex/tex.go
@@ -5,16 +5,21 @@
 package tex
 
 import (
+	_ "embed"
 	"strings"
 	"unicode"
 
 	"github.com/goki/ki/indent"
 	"github.com/goki/pi/filecat"
+	"github.com/goki/pi/langs"
 	"github.com/goki/pi/langs/bibtex"
 	"github.com/goki/pi/lex"
 	"github.com/goki/pi/pi"
 	"github.com/goki/pi/syms"
 )
+
+//go:embed tex.pi
+var parserBytes []byte
 
 // TexLang implements the Lang interface for the Tex / LaTeX language
 type TexLang struct {
@@ -27,6 +32,7 @@ var TheTexLang = TexLang{}
 
 func init() {
 	pi.StdLangProps[filecat.TeX].Lang = &TheTexLang
+	langs.ParserBytes[filecat.TeX] = parserBytes
 }
 
 func (tl *TexLang) Parser() *pi.Parser {


### PR DESCRIPTION
this lets Bazel work and keeps all language-specific code in the language-specific files.